### PR TITLE
fix: Overwrite package files when the published repository is switched to the new snapshot contents

### DIFF
--- a/aptly-sync-dists.sh
+++ b/aptly-sync-dists.sh
@@ -52,7 +52,7 @@ for DISTRIBUTION in ${!DISTRIBUTIONS[@]}; do
     echo "# Aptly publish - $DISTRIBUTION"
     echo "###"
     if aptly publish show ${DISTRIBUTION} ${ENDPOINT}:${PREFIX}; then
-        aptly publish switch -component=${DISTRIBUTIONS[$DISTRIBUTION]// /,} \
+        aptly publish switch -force-overwrite -component=${DISTRIBUTIONS[$DISTRIBUTION]// /,} \
             ${DISTRIBUTION} ${ENDPOINT}:${PREFIX} ${SNAPSHOTS}
     else
         aptly publish snapshot -component=${DISTRIBUTIONS[$DISTRIBUTION]// /,} \

--- a/aptly-sync-flat.sh
+++ b/aptly-sync-flat.sh
@@ -45,7 +45,7 @@ for DISTRIBUTION in ${!DISTRIBUTIONS[@]}; do
     echo "###"
     PREFIX="${PRODUCT}/${DISTRIBUTIONS[$DISTRIBUTION]}"
     if aptly publish show $DISTRIBUTION-$PRODUCT ${ENDPOINT}:${PREFIX}; then
-        aptly publish switch $DISTRIBUTION-$PRODUCT ${ENDPOINT}:${PREFIX} $DISTRIBUTION-$PRODUCT-$TAG
+        aptly publish switch -force-overwrite $DISTRIBUTION-$PRODUCT ${ENDPOINT}:${PREFIX} $DISTRIBUTION-$PRODUCT-$TAG
     else
         aptly publish snapshot -distribution=$DISTRIBUTION-$PRODUCT $DISTRIBUTION-$PRODUCT-$TAG ${ENDPOINT}:${PREFIX}
     fi


### PR DESCRIPTION
Switching snapshots or updating published repositories: if previous state and new state contain two conflicting packages, aptly would give an error. If you’re completely sure that this update operation is correct, you can use flag -force-overwrite to disable check for conflicting package files.