### PR TITLE
refactor: Standardize date format to ISO 8601

### DIFF
--- a/aptly-sync-dists.sh
+++ b/aptly-sync-dists.sh
@@ -4,7 +4,7 @@
 set -e
 
 CONFIG=${1:-debian}
-TAG=${2:-$(date +%Y%m%d%H%M)}
+TAG=${2:-$(date +%Y%m%d)}
 
 if [ -f "${BASH_SOURCE%/*}/config/dists/aptly-${CONFIG}.conf" ]; then
     source "${BASH_SOURCE%/*}/config/dists/aptly-${CONFIG}.conf"

--- a/aptly-sync-flat.sh
+++ b/aptly-sync-flat.sh
@@ -3,7 +3,7 @@
 set -e
 
 CONFIG=${1}
-TAG=${2:-$(date +%Y%m%d%H%M)}
+TAG=${2:-$(date +%Y%m%d)}
 
 if [ -f "${BASH_SOURCE%/*}/config/flat/aptly-${CONFIG}.conf" ]; then
     source "${BASH_SOURCE%/*}/config/flat/aptly-${CONFIG}.conf"


### PR DESCRIPTION
To simplify snapshot publication management, the date format should be switched to `YYYYMMMDD`.